### PR TITLE
Add a dot inside the dial indicator

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -790,6 +790,12 @@ class _DialPainter extends CustomPainter {
     selectorPaint.strokeWidth = 2.0;
     canvas.drawLine(centerPoint, focusedPoint, selectorPaint);
 
+    // Add a dot inside the selector but only when it isn't over the labels.
+    final double labelThetaIncrement = -_kTwoPi / primaryLabels.length;
+    if (theta % labelThetaIncrement > 0.1 && theta % labelThetaIncrement < 0.45) {
+      canvas.drawCircle(focusedPoint, 2.0, selectorPaint..color = backgroundColor);
+    }
+
     final Rect focusedRect = Rect.fromCircle(
       center: focusedPoint, radius: focusedRadius,
     );

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -791,6 +791,9 @@ class _DialPainter extends CustomPainter {
     canvas.drawLine(centerPoint, focusedPoint, selectorPaint);
 
     // Add a dot inside the selector but only when it isn't over the labels.
+    // This checks that the selector's theta is between two labels. A remainder
+    // between 0.1 and 0.45 indicates that the selector is roughly not above any
+    // labels. The values were derived by manually testing the dial.
     final double labelThetaIncrement = -_kTwoPi / primaryLabels.length;
     if (theta % labelThetaIncrement > 0.1 && theta % labelThetaIncrement < 0.45) {
       canvas.drawCircle(focusedPoint, 2.0, selectorPaint..color = backgroundColor);


### PR DESCRIPTION
## Description

This PR adds a small dot inside the dial selector. The dot does not appear when the selector is over top of a label. See screenshots

<img width="300" alt="Screen Shot 2020-04-30 at 2 11 52 PM" src="https://user-images.githubusercontent.com/2364772/80744735-20c6c080-8aed-11ea-8393-6f99e24991c2.png"><img width="300" alt="Screen Shot 2020-04-30 at 2 15 44 PM" src="https://user-images.githubusercontent.com/2364772/80744736-215f5700-8aed-11ea-95ae-0b4a740ead4f.png">

