### PR TITLE
Update time picker a11y experience

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1793,8 +1793,8 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
       case TimePickerEntryMode.dial:
         final Widget dial = Padding(
           padding: EdgeInsets.symmetric(horizontal: orientation == Orientation.portrait ? 36.0 : 24.0, vertical: 24.0),
-          // Allows for a smoother transition from dial to input mode.
           child: ExcludeSemantics(
+            // Allows for a smoother transition from dial to input mode.
             child: SingleChildScrollView(
               scrollDirection: orientation == Orientation.portrait ? Axis.vertical : Axis.horizontal,
               child: AspectRatio(

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1766,7 +1766,9 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
           onPressed: _handleEntryModeToggle,
           icon: Icon(_entryMode == TimePickerEntryMode.dial ? Icons.keyboard : Icons.access_time),
           // TODO(rami-a): Localize these strings.
-          tooltip: _entryMode == TimePickerEntryMode.dial ? 'Switch to text input' : 'Switch to clock', // TODO: Are this the correct strings?
+          tooltip: _entryMode == TimePickerEntryMode.dial
+              ? 'Switch to text input mode'
+              : 'Switch to dial picker mode',
         ),
         Expanded(
           child: ButtonBar(

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -817,70 +817,6 @@ class _DialPainter extends CustomPainter {
     canvas.restore();
   }
 
-  static const double _semanticNodeSizeScale = 1.5;
-
-  @override
-  SemanticsBuilderCallback get semanticsBuilder => _buildSemantics;
-
-  /// Creates semantics nodes for the hour/minute labels painted on the dial.
-  ///
-  /// The nodes are positioned on top of the text and their size is
-  /// [_semanticNodeSizeScale] bigger than those of the text boxes to provide
-  /// bigger tap area.
-  List<CustomPainterSemantics> _buildSemantics(Size size) {
-    final double radius = size.shortestSide / 2.0;
-    final Offset center = Offset(size.width / 2.0, size.height / 2.0);
-    final double labelRadius = radius - _labelPadding;
-
-    Offset getOffsetForTheta(double theta) {
-      return center + Offset(labelRadius * math.cos(theta),
-          -labelRadius * math.sin(theta));
-    }
-
-    final List<CustomPainterSemantics> nodes = <CustomPainterSemantics>[];
-
-    void paintLabels(List<_TappableLabel> labels) {
-      if (labels == null)
-        return;
-      final double labelThetaIncrement = -_kTwoPi / labels.length;
-      double labelTheta = math.pi / 2.0;
-
-      for (int i = 0; i < labels.length; i++) {
-        final _TappableLabel label = labels[i];
-        final TextPainter labelPainter = label.painter;
-        final double width = labelPainter.width * _semanticNodeSizeScale;
-        final double height = labelPainter.height * _semanticNodeSizeScale;
-        final Offset nodeOffset = getOffsetForTheta(labelTheta) + Offset(-width / 2.0, -height / 2.0);
-        final TextSpan textSpan = labelPainter.text as TextSpan;
-        final CustomPainterSemantics node = CustomPainterSemantics(
-          rect: Rect.fromLTRB(
-            nodeOffset.dx - 24.0 + width / 2,
-            nodeOffset.dy - 24.0 + height / 2,
-            nodeOffset.dx + 24.0 + width / 2,
-            nodeOffset.dy + 24.0 + height / 2,
-          ),
-          properties: SemanticsProperties(
-            sortKey: OrdinalSortKey(i.toDouble()),
-            selected: label.value == selectedValue,
-            value: textSpan?.text,
-            textDirection: textDirection,
-            onTap: label.onTap,
-          ),
-          tags: const <SemanticsTag>{
-            // Used by tests to find this node.
-            SemanticsTag('dial-label'),
-          },
-        );
-        nodes.add(node);
-        labelTheta += labelThetaIncrement;
-      }
-    }
-
-    paintLabels(primaryLabels);
-
-    return nodes;
-  }
-
   @override
   bool shouldRepaint(_DialPainter oldPainter) {
     return oldPainter.primaryLabels != primaryLabels
@@ -1427,8 +1363,10 @@ class _TimePickerInputState extends State<_TimePickerInput> {
                   ),
                   const SizedBox(height: 8.0),
                   if (!hourHasError && !minuteHasError)
-                    // TODO(rami-a): localize 'Hour'
-                    Text('Hour', style: theme.textTheme.caption),
+                    ExcludeSemantics(
+                      // TODO(rami-a): localize 'Hour'
+                      child: Text('Hour', style: theme.textTheme.caption),
+                    ),
                 ],
               )),
               Padding(
@@ -1451,8 +1389,10 @@ class _TimePickerInputState extends State<_TimePickerInput> {
                   ),
                   const SizedBox(height: 8.0),
                   if (!hourHasError && !minuteHasError)
-                    // TODO(rami-a): localize 'Minute'
-                    Text('Minute', style: theme.textTheme.caption),
+                    ExcludeSemantics(
+                      // TODO(rami-a): localize 'Minute'
+                      child: Text('Minute', style: theme.textTheme.caption),
+                    ),
                 ],
               )),
               if (!use24HourDials) ...<Widget>[
@@ -1825,6 +1765,8 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
           color: toggleColor,
           onPressed: _handleEntryModeToggle,
           icon: Icon(_entryMode == TimePickerEntryMode.dial ? Icons.keyboard : Icons.access_time),
+          // TODO(rami-a): Localize these strings.
+          tooltip: _entryMode == TimePickerEntryMode.dial ? 'Switch to text input' : 'Switch to clock', // TODO: Are this the correct strings?
         ),
         Expanded(
           child: ButtonBar(
@@ -1850,16 +1792,18 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
         final Widget dial = Padding(
           padding: EdgeInsets.symmetric(horizontal: orientation == Orientation.portrait ? 36.0 : 24.0, vertical: 24.0),
           // Allows for a smoother transition from dial to input mode.
-          child: SingleChildScrollView(
-            scrollDirection: orientation == Orientation.portrait ? Axis.vertical : Axis.horizontal,
-            child: AspectRatio(
-              aspectRatio: 1.0,
-              child: _Dial(
-                mode: _mode,
-                use24HourDials: use24HourDials,
-                selectedTime: _selectedTime,
-                onChanged: _handleTimeChanged,
-                onHourSelected: _handleHourSelected,
+          child: ExcludeSemantics(
+            child: SingleChildScrollView(
+              scrollDirection: orientation == Orientation.portrait ? Axis.vertical : Axis.horizontal,
+              child: AspectRatio(
+                aspectRatio: 1.0,
+                child: _Dial(
+                  mode: _mode,
+                  use24HourDials: use24HourDials,
+                  selectedTime: _selectedTime,
+                  onChanged: _handleTimeChanged,
+                  onHourSelected: _handleHourSelected,
+                ),
               ),
             ),
           ),

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -338,10 +338,10 @@ void _tests() {
     await mediaQueryBoilerplate(tester, true);
 
     expect(semantics, isNot(includesNodeWith(label: ':')));
-    expect(semantics.nodesWith(value: '00'), hasLength(2),
-        reason: '00 appears once in the header, then again in the dial');
+    expect(semantics.nodesWith(value: '00'), hasLength(1),
+        reason: '00 appears once in the header');
     expect(semantics.nodesWith(value: '07'), hasLength(1),
-        reason: '07 appears once in the header, but not in the dial');
+        reason: '07 appears once in the header');
     expect(semantics, includesNodeWith(label: 'CANCEL'));
     expect(semantics, includesNodeWith(label: 'OK'));
 
@@ -349,58 +349,6 @@ void _tests() {
     expect(semantics, isNot(includesNodeWith(label: 'AM')));
     expect(semantics, isNot(includesNodeWith(label: 'PM')));
 
-    semantics.dispose();
-  });
-  
-  testWidgets('provides semantics information for hours', (WidgetTester tester) async {
-    final SemanticsTester semantics = SemanticsTester(tester);
-    await mediaQueryBoilerplate(tester, true);
-
-    final CustomPaint dialPaint = tester.widget(find.byKey(const ValueKey<String>('time-picker-dial')));
-    final CustomPainter dialPainter = dialPaint.painter;
-    final _CustomPainterSemanticsTester painterTester = _CustomPainterSemanticsTester(tester, dialPainter, semantics);
-
-    painterTester.addLabel('00');
-    painterTester.addLabel('02');
-    painterTester.addLabel('04');
-    painterTester.addLabel('06');
-    painterTester.addLabel('08');
-    painterTester.addLabel('10');
-    painterTester.addLabel('12');
-    painterTester.addLabel('14');
-    painterTester.addLabel('16');
-    painterTester.addLabel('18');
-    painterTester.addLabel('20');
-    painterTester.addLabel('22');
-
-    painterTester.assertExpectations();
-    semantics.dispose();
-  });
-
-  testWidgets('provides semantics information for minutes', (WidgetTester tester) async {
-    final SemanticsTester semantics = SemanticsTester(tester);
-    await mediaQueryBoilerplate(tester, true);
-    await tester.tap(_minuteControl);
-    await tester.pumpAndSettle();
-
-    final CustomPaint dialPaint = tester.widget(find.byKey(const ValueKey<String>('time-picker-dial')));
-    final CustomPainter dialPainter = dialPaint.painter;
-    final _CustomPainterSemanticsTester painterTester = _CustomPainterSemanticsTester(tester, dialPainter, semantics);
-
-    painterTester.addLabel('00');
-    painterTester.addLabel('05');
-    painterTester.addLabel('10');
-    painterTester.addLabel('15');
-    painterTester.addLabel('20');
-    painterTester.addLabel('25');
-    painterTester.addLabel('30');
-    painterTester.addLabel('35');
-    painterTester.addLabel('40');
-    painterTester.addLabel('45');
-    painterTester.addLabel('50');
-    painterTester.addLabel('55');
-
-    painterTester.assertExpectations();
     semantics.dispose();
   });
 
@@ -818,60 +766,6 @@ final Finder findDialPaint = find.descendant(
   of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_Dial'),
   matching: find.byWidgetPredicate((Widget w) => w is CustomPaint),
 );
-
-class _CustomPainterSemanticsTester {
-  _CustomPainterSemanticsTester(this.tester, this.painter, this.semantics);
-
-  final WidgetTester tester;
-  final CustomPainter painter;
-  final SemanticsTester semantics;
-  final PaintPattern expectedLabels = paints;
-  final List<String> expectedNodes = <String>[];
-
-  void addLabel(String label) {
-    expectedNodes.add(label);
-  }
-
-  void assertExpectations() {
-    final TestRecordingCanvas canvasRecording = TestRecordingCanvas();
-    painter.paint(canvasRecording, const Size(220.0, 220.0));
-    final List<ui.Paragraph> paragraphs = canvasRecording.invocations
-      .where((RecordedInvocation recordedInvocation) {
-        return recordedInvocation.invocation.memberName == #drawParagraph;
-      })
-      .map<ui.Paragraph>((RecordedInvocation recordedInvocation) {
-        return recordedInvocation.invocation.positionalArguments.first as ui.Paragraph;
-      })
-      .toList();
-
-    final PaintPattern expectedLabels = paints;
-    int i = 0;
-
-    for (final String expectation in expectedNodes) {
-      expect(semantics, includesNodeWith(value: expectation));
-      final Iterable<SemanticsNode> dialLabelNodes = semantics
-          .nodesWith(value: expectation)
-          .where((SemanticsNode node) => node.tags?.contains(const SemanticsTag('dial-label')) ?? false);
-      expect(dialLabelNodes, hasLength(1), reason: 'Expected exactly one label $expectation');
-
-      final ui.Paragraph paragraph = paragraphs[i++];
-
-      // The label text paragraph and the semantics node share the same center,
-      // but have different sizes.
-      final Offset center = dialLabelNodes.single.rect.center;
-      final Offset topLeft = center.translate(
-        -paragraph.width / 2.0,
-        -paragraph.height / 2.0,
-      );
-
-      expectedLabels.paragraph(
-        paragraph: paragraph,
-        offset: within<Offset>(distance: 1.0, from: topLeft),
-      );
-    }
-    expect(tester.renderObject(findDialPaint), expectedLabels);
-  }
-}
 
 class PickerObserver extends NavigatorObserver {
   int pickerCount = 0;


### PR DESCRIPTION
## Description

This PR updates the a11y experience for time picker:
- The dial is no longer accessible since it added an additional layer of friction for screen readers. 
- Labels were added to icon buttons
- Hour/minute text widgets were excluded in input mode

## Tests

I added the following tests:

- Removed unnecessary tests since semantics changed
- Modified existing tests
